### PR TITLE
added port forwarding from localhost to AMP server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,10 +27,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if server.has_key?("ip")
         server_config.vm.network "private_network", ip: server["ip"]
       end
-
+      #the port mapping config is in servers.yaml. In the event that auto-correction fails, please edit the port mappings in that file 
       if server.has_key?("forwarded_ports")
         server["forwarded_ports"].each do |ports|
-          server_config.vm.network "forwarded_port", guest: ports["guest"], host: ports["host"], guest_ip: ports["guest_ip"]
+          server_config.vm.network "forwarded_port", guest: ports["guest"], host: ports["host"], guest_ip: ports["guest_ip"], auto_correct: true
         end
       end
 

--- a/servers.yaml
+++ b/servers.yaml
@@ -8,6 +8,9 @@ servers:
     ram: 2048
     cpus: 4
     ip: 10.10.10.100
+    forwarded_ports:
+     - guest: 8081
+       host: 8081
     shell:
       env:
         AMP_PRO_VERSION: 3.1.0-20160330.1541


### PR DESCRIPTION
adding this means we can simplify the Getting Started guide to remove the dual instructions for Vagrant and for a local install