### PR TITLE
Update CentOS box and enable password auth

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -16,23 +16,39 @@ servers:
       cmd:
         - /vagrant/files/install_amp.sh
   - name: byon1
-    box: bento/centos-6.7
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.101
+    shell:
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon2
-    box: bento/centos-6.7
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.102
+    shell:
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon3
-    box: bento/centos-6.7
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.103
+    shell:
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon4
-    box: bento/centos-6.7
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.104
+    shell:
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
 ...


### PR DESCRIPTION
* Use latest CentOS 7 Vagrant box
* Allow password authentication, required for [this guide](http://docs.cloudsoft.io/tutorials/tutorial-get-amp-running.html) to work -- previously SSH would fail on CentOS boxes 