### PR TITLE
path tweaks to get amp install working

### DIFF
--- a/files/install_amp.sh
+++ b/files/install_amp.sh
@@ -37,12 +37,14 @@ echo "Install AMP"
 sudo yum -y install cloudsoft-amp-karaf-noarch.rpm
 
 echo "Configure AMP Properties"
-sudo cp /vagrant/files/brooklyn.properties /etc/amp/brooklyn.cfg
+#sudo cp /vagrant/files/brooklyn.properties /etc/amp/brooklyn.cfg
+sudo cp /home/vagrant/sync/files/brooklyn.properties /etc/amp/brooklyn.cfg
 sudo chown amp:amp /etc/amp/brooklyn.cfg
 sudo chmod 600 /etc/amp/brooklyn.cfg
 
 echo "Configure MOTD"
-sudo cp /vagrant/files/motd /etc/motd
+#sudo cp /vagrant/files/motd /etc/motd
+sudo cp /home/vagrant/sync/files/motd /etc/motd
 
 echo "Starting AMP..."
 sudo systemctl start amp

--- a/servers.yaml
+++ b/servers.yaml
@@ -14,7 +14,8 @@ servers:
        autocorrect: true
     shell:
       cmd:
-        - /vagrant/files/install_amp.sh
+        #- /vagrant/files/install_amp.sh
+        - /home/vagrant/sync/files/install_amp.sh
   - name: byon1
     box: centos/7
     ram: 512


### PR DESCRIPTION
AMP install on vagrant wasn't working - looks like paths from vagrant to install files has changed. Not sure why - is this an issue for others? Or just me?